### PR TITLE
Avoid duplicate main tags

### DIFF
--- a/web/app/themes/thepoliticalsage/templates/content-page.php
+++ b/web/app/themes/thepoliticalsage/templates/content-page.php
@@ -1,4 +1,4 @@
-<main class="page responsive-text">
+<section class="page responsive-text">
     <section class="text-wrapper">
         <div class="letterhead">
             <i class="fa fa-star star"></i> 
@@ -11,5 +11,5 @@
         </div>
         <?php the_content(); ?>
     </section>
-</main>
+</section>
 <?php wp_link_pages(['before' => '<nav class="page-nav"><p>' . __('Pages:', 'sage'), 'after' => '</p></nav>']); ?>


### PR DESCRIPTION
Ideally I would remove the lone opening tag from the header file
and the lone closing tag from the footer file, but it seems most
pages are depending on those.

Changes duplicate `<main>` to `<section>`.